### PR TITLE
Add blur effect

### DIFF
--- a/src/components/Compose/Compose.css
+++ b/src/components/Compose/Compose.css
@@ -3,12 +3,26 @@
   display: flex;
   align-items: center;
   background: white;
+  border-top: 1px solid #eeeef1;
+  position: fixed;
+  width: calc(100% - 20px);
+  bottom: 0px;
+}
+
+@supports (backdrop-filter: blur(20px)) {
+  .compose {
+    border: none;
+    background-color: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(20px);
+  }
 }
 
 .compose-input {
   flex: 1;
   border: none;
   font-size: 14px;
+  height: 40px;
+  background: none;
 }
 
 .compose-input::placeholder {

--- a/src/components/ConversationList/index.js
+++ b/src/components/ConversationList/index.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import ConversationSearch from '../ConversationSearch';
 import ConversationListItem from '../ConversationListItem';
+import Toolbar from '../Toolbar';
+import ToolbarButton from '../ToolbarButton';
 import axios from 'axios';
 
 import './ConversationList.css';
@@ -36,6 +38,15 @@ export default class ConversationList extends Component {
   render() {
     return (
       <div className="conversation-list">
+        <Toolbar
+          title="Messenger"
+          leftItems={[
+            <ToolbarButton key="cog" icon="ion-ios-cog" />
+          ]}
+          rightItems={[
+            <ToolbarButton key="add" icon="ion-ios-add-circle-outline" />
+          ]}
+        />
         <ConversationSearch />
         {
           this.state.conversations.map(conversation =>

--- a/src/components/ConversationListItem/ConversationListItem.css
+++ b/src/components/ConversationListItem/ConversationListItem.css
@@ -1,7 +1,7 @@
 .conversation-list-item {
   display: flex;
   align-items: center;
-  padding: 6px 10px;
+  padding: 10px;
 }
 
 .conversation-list-item:hover {
@@ -10,16 +10,16 @@
 }
 
 .conversation-photo {
-  width: 64px;
-  height: 64px;
+  width: 50px;
+  height: 50px;
   border-radius: 50%;
   object-fit: cover;
   margin-right: 10px;
 }
 
 .conversation-title {
-  font-size: 16px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: bold;
   text-transform: capitalize;
   margin: 0;
 }

--- a/src/components/ConversationSearch/ConversationSearch.css
+++ b/src/components/ConversationSearch/ConversationSearch.css
@@ -7,7 +7,7 @@
 .conversation-search-input {
   background: #f4f4f8;
   padding: 8px 10px;
-  border-radius: 5px;
+  border-radius: 10px;
   border: none;
   font-size: 14px;
 }

--- a/src/components/Message/Message.css
+++ b/src/components/Message/Message.css
@@ -7,9 +7,10 @@
   display: flex;
   justify-content: center;
   color: #999;
-  font-weight: 500;
-  font-size: 14px;
+  font-weight: 600;
+  font-size: 12px;
   margin: 10px 0px;
+  text-transform: uppercase;
 }
 
 .message .bubble-container {
@@ -22,13 +23,13 @@
 }
 
 .message.start .bubble-container .bubble {
-  margin-top: 10px;
+  /* margin-top: 10px; */
   border-top-left-radius: 20px;
 }
 
 .message.end .bubble-container .bubble {
   border-bottom-left-radius: 20px;
-  margin-bottom: 10px;
+  /* margin-bottom: 10px; */
 }
 
 .message.mine.start .bubble-container .bubble {

--- a/src/components/Message/index.js
+++ b/src/components/Message/index.js
@@ -27,8 +27,10 @@ export default class Message extends Component {
             </div>
         }
 
-        <div className="bubble-container" title={friendlyTimestamp}>
-          <div className="bubble">{ data.message }</div>
+        <div className="bubble-container">
+          <div className="bubble" title={friendlyTimestamp}>
+            { data.message }
+          </div>
         </div>
       </div>
     );

--- a/src/components/MessageList/MessageList.css
+++ b/src/components/MessageList/MessageList.css
@@ -1,3 +1,4 @@
-.message-list {
-  /* TODO */
+.message-list-container {
+  padding: 10px;
+  padding-bottom: 70px;
 }

--- a/src/components/MessageList/index.js
+++ b/src/components/MessageList/index.js
@@ -1,4 +1,7 @@
 import React, { Component } from 'react';
+import Compose from '../Compose';
+import Toolbar from '../Toolbar';
+import ToolbarButton from '../ToolbarButton';
 import Message from '../Message';
 import moment from 'moment';
 
@@ -150,18 +153,25 @@ export default class MessageList extends Component {
   render() {
     return(
       <div className="message-list">
-      {
-        this.renderMessages()
-        // messages.map(message => {
-        //   return (
-        //     <Message
-        //       data={message}
-        //       key={message.id}
-        //       isMine={message.author === MY_USER_ID}
-        //       showTimestamp={false}
-        //     />)
-        // })
-      }
+        <Toolbar
+          title="Conversation Title"
+          rightItems={[
+            <ToolbarButton key="info" icon="ion-ios-information-circle-outline" />,
+            <ToolbarButton key="video" icon="ion-ios-videocam" />,
+            <ToolbarButton key="phone" icon="ion-ios-call" />
+          ]}
+        />
+
+        <div className="message-list-container">{this.renderMessages()}</div>
+
+        <Compose rightItems={[
+          <ToolbarButton key="photo" icon="ion-ios-camera" />,
+          <ToolbarButton key="image" icon="ion-ios-image" />,
+          <ToolbarButton key="audio" icon="ion-ios-mic" />,
+          <ToolbarButton key="money" icon="ion-ios-card" />,
+          <ToolbarButton key="games" icon="ion-logo-game-controller-b" />,
+          <ToolbarButton key="emoji" icon="ion-ios-happy" />
+        ]}/>
       </div>
     );
   }

--- a/src/components/Messenger/Messenger.css
+++ b/src/components/Messenger/Messenger.css
@@ -5,28 +5,31 @@
   background: #eeeef1;
 
   grid-template-columns: 350px auto;
-  grid-template-rows: 50px auto 50px;
+  grid-template-rows: 60px auto 60px;
   grid-column-gap: 1px;
   grid-row-gap: 1px;
 }
 
 .container {
-  padding: 11px;
+  padding: 10px;
 }
 
 .scrollable {
+  position: relative;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 }
 
 .sidebar {
   background: white;
-  grid-row-start: 2;
-  grid-row-end: span 2;
+  grid-row-start: 1;
+  grid-row-end: span 3;
 }
 
 .content {
   background: white;
+  grid-row-start: 1;
+  grid-row-end: span 3;
 }
 
 .footer {

--- a/src/components/Messenger/index.js
+++ b/src/components/Messenger/index.js
@@ -1,16 +1,13 @@
 import React, { Component } from 'react';
-import Toolbar from '../Toolbar';
-import ToolbarButton from '../ToolbarButton';
 import ConversationList from '../ConversationList';
 import MessageList from '../MessageList';
-import Compose from '../Compose';
 import './Messenger.css';
 
 export default class Messenger extends Component {
   render() {
     return (
       <div className="messenger">
-        <Toolbar
+        {/* <Toolbar
           title="Messenger"
           leftItems={[
             <ToolbarButton key="cog" icon="ion-ios-cog" />
@@ -18,33 +15,24 @@ export default class Messenger extends Component {
           rightItems={[
             <ToolbarButton key="add" icon="ion-ios-add-circle-outline" />
           ]}
-        />
+        /> */}
 
-        <Toolbar
+        {/* <Toolbar
           title="Conversation Title"
           rightItems={[
             <ToolbarButton key="info" icon="ion-ios-information-circle-outline" />,
             <ToolbarButton key="video" icon="ion-ios-videocam" />,
             <ToolbarButton key="phone" icon="ion-ios-call" />
           ]}
-        />
+        /> */}
 
         <div className="scrollable sidebar">
           <ConversationList />
         </div>
 
-        <div className="scrollable container content">
+        <div className="scrollable content">
           <MessageList />
         </div>
-
-        <Compose rightItems={[
-          <ToolbarButton icon="ion-ios-camera" />,
-          <ToolbarButton icon="ion-ios-image" />,
-          <ToolbarButton icon="ion-ios-mic" />,
-          <ToolbarButton icon="ion-ios-card" />,
-          <ToolbarButton icon="ion-logo-game-controller-b" />,
-          <ToolbarButton icon="ion-ios-happy" />
-        ]}/>
       </div>
     );
   }

--- a/src/components/Toolbar/Toolbar.css
+++ b/src/components/Toolbar/Toolbar.css
@@ -4,12 +4,24 @@
 
   background-color: white;
   font-weight: 500;
+  border-bottom: 1px solid #eeeef1;
+
+  position: sticky;
+  top: 0px;
+}
+
+@supports (backdrop-filter: blur(20px)) {
+  .toolbar {
+    border: none;
+    background-color: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(20px);
+  }
 }
 
 .toolbar-title {
   margin: 0;
   font-size: 16px;
-  font-weight: 500;
+  font-weight: 800;
 }
 
 .left-items, .right-items {

--- a/src/components/ToolbarButton/ToolbarButton.css
+++ b/src/components/ToolbarButton/ToolbarButton.css
@@ -1,9 +1,15 @@
 .toolbar-button {
   color: #007aff;
   font-size: 28px;
+  transition: all 0.1s;
 }
 
 .toolbar-button:hover {
   cursor: pointer;
   color: #0063ce;
+}
+
+.toolbar-button:active {
+  color: #007aff;
+  opacity: 0.25;
 }


### PR DESCRIPTION
I rearranged the grid layout and put toolbars/compose bar directly inside the sidebar and content panes. This allows us to use a blur effect that helps it better resemble the iOS mobile application. If your web browser does not support `backdrop-blur`, it looks exactly the same as it did before, border and everything.